### PR TITLE
change api so can specify blocking or nonBlocking approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Flowable<String> items =
 
 The above example uses a ```WatchService``` to generate ```WatchEvent```s to prompt rereads of the end of the file to perform the tail.
 
-To use polling instead (say every 5 seconds):
+To use polling without a `WatchService` (say every 5 seconds):
 
 ```java
 Flowable<String> items = 
@@ -95,7 +95,8 @@ Flowable<byte[]> items =
 ```java
 Flowable<WatchEvent<?>> events = 
   Files
-    .events(file)
+    .watch(file)
+    .nonBlocking()
     .scheduler(Schedulers.io())
     .pollInterval(1, TimeUnit.MINUTES)
     .build();

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Flowable<String> items =
 ### Tail a binary file with NIO
 ```java
 Flowable<byte[]> items = 
-  Files.tailBytes("/tmp/dump.bin").build();
+  Files.tailBytes("/tmp/dump.bin").blocking().build();
 ```
 
 ### Tail a binary file without NIO
@@ -101,6 +101,10 @@ Flowable<WatchEvent<?>> events =
     .pollInterval(1, TimeUnit.MINUTES)
     .build();
 ```
+## Non-blocking and blocking
+Two alternatives are supported by the library for getting file change events from a `WatchService`. The `nonBlocking()` builder methods configure the stream to use events via `WatchService.poll` which is a non-blocking call (but may involve some I/O?). The `blocking()` builder methods configure the stream to use events via `WatchService.take` which is a blocking call.
+
+So when specify `nonBlocking()` you end up with a stream that is asynchronous and `blocking()` gives you a synchronous stream (everything happens on the current thread unless of course you add asynchrony to the returned `Flowable`).
 
 ## OSX
 Apparently the `WatchService` can be slow on OSX (see [here](https://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else)). Note that the first example above shows how to pass a special `WatchEvent.Modifier` which some find has a beneficial effect. Without that the `WatchService` can take >10 seconds to detect changes to the file system.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Flowable<WatchEvent<?>> events =
     .pollInterval(1, TimeUnit.MINUTES)
     .build();
 ```
+## Backpressure
+When `tailLines` or `tailBytes` is used a conversion to `Flowable` occurs on the `WatchEvent` stream. This is desirable to handle large amounts of data being tailed in combination with a slow processor (e.g. a network call). The default strategy is BUFFER but the strategy is specifiable in the `tailLines` and `tailBytes` builders.
+ 
 ## Non-blocking and blocking
 Two alternatives are supported by the library for getting file change events from a `WatchService`. The `nonBlocking()` builder methods configure the stream to use events via `WatchService.poll` which is a non-blocking call (but may involve some I/O?). The `blocking()` builder methods configure the stream to use events via `WatchService.take` which is a blocking call.
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ import com.github.davidmoten.rx2.file.Files;
 
 Flowable<String> lines = 
      Files.tailLines("/var/log/server.log")
-          .pollingInterval(500, TimeUnit.MILLISECONDS)
-          .scheduler(Schedulers.io())
+          .nonBlocking()
+          .pollingInterval(500, TimeUnit.MILLISECONDS, Schedulers.io())
           // set a private sun modifier that improves OSX responsiveness
           .modifier(SensitivityWatchEventModifier.HIGH)
           .startPosition(0)
@@ -61,7 +61,7 @@ Flowable<String> lines =
 or, using defaults of startPosition 0, chunkSize 8192, charset UTF-8, scheduler `Schedulers.io()`:
 ```java
 Flowable<String> items = 
-     Files.tailLines("/var/log/server.log").build();
+     Files.tailLines("/var/log/server.log").nonBlocking().build();
 	  
 ```
 ### Tail a text file without NIO

--- a/src/main/java/com/github/davidmoten/rx2/file/Files.java
+++ b/src/main/java/com/github/davidmoten/rx2/file/Files.java
@@ -278,7 +278,7 @@ public final class Files {
             return false;
     };
 
-    public static WatchEventsBuilder events(File file) {
+    public static WatchEventsBuilder watch(File file) {
         return new WatchEventsBuilder(file);
     }
 

--- a/src/test/java/com/github/davidmoten/rx2/file/FilesTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/file/FilesTest.java
@@ -7,7 +7,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -17,6 +16,8 @@ import org.junit.Test;
 
 import com.github.davidmoten.guavamini.Lists;
 
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.Schedulers;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subscribers.TestSubscriber;
 
@@ -42,10 +43,10 @@ public class FilesTest {
         file.delete();
         AtomicInteger errors = new AtomicInteger();
         TestScheduler scheduler = new TestScheduler();
-        TestSubscriber<String> ts = Files //
+        TestObserver<String> ts = Files //
                 .events(file) //
-                .scheduler(scheduler) //
-                .pollInterval(1, TimeUnit.MINUTES) //
+                .nonBlocking() //
+                .pollInterval(1, TimeUnit.MINUTES, scheduler) //
                 .build() //
                 .doOnNext(x -> System.out.println(x.kind().name() + ", count=" + x.count())) //
                 .map(x -> x.kind().name()).take(3) //
@@ -88,6 +89,23 @@ public class FilesTest {
             checkTailFile(MAX_WAIT_MS);
         }
     }
+    
+    @Test
+    public void testTailFileBlocking() throws InterruptedException, FileNotFoundException {
+        System.out.println("os.name=" + System.getProperty("os.name"));
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            System.out.println("ignoring test because Windows is problematic in detecting file change events");
+            return;
+        }
+        try {
+            checkTailFileBlocking(100);
+        } catch (AssertionError e) {
+            // fallback to 30s waits because OSX can be really slow
+            // see
+            // https://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else
+            checkTailFileBlocking(MAX_WAIT_MS);
+        }
+    }
 
     private void checkTailFile(long waitMs) throws InterruptedException, FileNotFoundException {
         System.out.println("checkTailFile waitMs=" + waitMs);
@@ -96,10 +114,34 @@ public class FilesTest {
         List<String> lines = new CopyOnWriteArrayList<>();
         TestSubscriber<String> ts = Files //
                 .tailLines(file) //
+                .nonBlocking() //
                 .pollingInterval(50, TimeUnit.MILLISECONDS) //
                 .build() //
                 .doOnNext(x -> lines.add(x)) //
                 .test();
+        checkChangesAreDetected(waitMs, file, ts);
+    }
+    
+    private void checkTailFileBlocking(long waitMs) throws InterruptedException, FileNotFoundException {
+        System.out.println("checkTailFile waitMs=" + waitMs);
+        File file = new File("target/lines.txt");
+        file.delete();
+        List<String> lines = new CopyOnWriteArrayList<>();
+        TestSubscriber<String> ts = Files //
+                .tailLines(file) //
+                .blocking() //
+                .build() //
+                .subscribeOn(Schedulers.io()) //
+                .doOnNext(x -> lines.add(x)) //
+                .doOnNext(System.out::println) //
+                .test();
+        checkChangesAreDetected(waitMs, file, ts);
+        System.out.println("lines="+ lines);
+    }
+
+
+    private void checkChangesAreDetected(long waitMs, File file, TestSubscriber<String> ts)
+            throws InterruptedException, FileNotFoundException {
         try {
             Thread.sleep(waitMs);
             try (PrintWriter out = new PrintWriter(file)) {
@@ -109,6 +151,7 @@ public class FilesTest {
                 out.flush();
                 // help windows some more
                 file.getParentFile().list();
+                ts.awaitCount(1);
 
                 Thread.sleep(waitMs);
                 ts.assertValues("a");
@@ -120,6 +163,7 @@ public class FilesTest {
                 // help windows some more
                 file.getParentFile().list();
                 Thread.sleep(waitMs);
+                ts.awaitCount(2);
                 ts.assertValues("a", "b");
             }
         } finally {
@@ -128,4 +172,8 @@ public class FilesTest {
         }
     }
 
+    public static void main(String[] args) {
+        Files.tailLines(new File("/home/dxm/temp.txt")).blocking().build().forEach(System.out::println);
+    }
+    
 }

--- a/src/test/java/com/github/davidmoten/rx2/file/FilesTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/file/FilesTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import com.github.davidmoten.guavamini.Lists;
 
+import io.reactivex.BackpressureStrategy;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.schedulers.TestScheduler;
@@ -77,7 +78,8 @@ public class FilesTest {
     public void testTailFile() throws InterruptedException, FileNotFoundException {
         System.out.println("os.name=" + System.getProperty("os.name"));
         if (System.getProperty("os.name").toLowerCase().contains("win")) {
-            System.out.println("ignoring test because Windows is problematic in detecting file change events");
+            System.out.println(
+                    "ignoring test because Windows is problematic in detecting file change events");
             return;
         }
         try {
@@ -89,12 +91,13 @@ public class FilesTest {
             checkTailFile(MAX_WAIT_MS);
         }
     }
-    
+
     @Test
     public void testTailFileBlocking() throws InterruptedException, FileNotFoundException {
         System.out.println("os.name=" + System.getProperty("os.name"));
         if (System.getProperty("os.name").toLowerCase().contains("win")) {
-            System.out.println("ignoring test because Windows is problematic in detecting file change events");
+            System.out.println(
+                    "ignoring test because Windows is problematic in detecting file change events");
             return;
         }
         try {
@@ -115,14 +118,16 @@ public class FilesTest {
         TestSubscriber<String> ts = Files //
                 .tailLines(file) //
                 .nonBlocking() //
+                .backpressureStrategy(BackpressureStrategy.BUFFER) //
                 .pollingInterval(50, TimeUnit.MILLISECONDS) //
                 .build() //
                 .doOnNext(x -> lines.add(x)) //
                 .test();
         checkChangesAreDetected(waitMs, file, ts);
     }
-    
-    private void checkTailFileBlocking(long waitMs) throws InterruptedException, FileNotFoundException {
+
+    private void checkTailFileBlocking(long waitMs)
+            throws InterruptedException, FileNotFoundException {
         System.out.println("checkTailFile waitMs=" + waitMs);
         File file = new File("target/lines.txt");
         file.delete();
@@ -136,9 +141,8 @@ public class FilesTest {
                 .doOnNext(System.out::println) //
                 .test();
         checkChangesAreDetected(waitMs, file, ts);
-        System.out.println("lines="+ lines);
+        System.out.println("lines=" + lines);
     }
-
 
     private void checkChangesAreDetected(long waitMs, File file, TestSubscriber<String> ts)
             throws InterruptedException, FileNotFoundException {
@@ -173,7 +177,8 @@ public class FilesTest {
     }
 
     public static void main(String[] args) {
-        Files.tailLines(new File("/home/dxm/temp.txt")).blocking().build().forEach(System.out::println);
+        Files.tailLines(new File("/home/dxm/temp.txt")).blocking().backpressureStrategy(BackpressureStrategy.LATEST).build()
+                .forEach(System.out::println);
     }
-    
+
 }

--- a/src/test/java/com/github/davidmoten/rx2/file/FilesTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/file/FilesTest.java
@@ -44,7 +44,7 @@ public class FilesTest {
         AtomicInteger errors = new AtomicInteger();
         TestScheduler scheduler = new TestScheduler();
         TestObserver<String> ts = Files //
-                .events(file) //
+                .watch(file) //
                 .nonBlocking() //
                 .pollInterval(1, TimeUnit.MINUTES, scheduler) //
                 .build() //


### PR DESCRIPTION
See discussion in #1. 

The library now has an intermediate builder class that forces the user to specify `blocking()` or `nonBlocking()`.

For example:
```java
Flowable<String> items = 
     Files.tailLines("/var/log/server.log").blocking().build();
```

The other change is that streams of `WatchEvent<?>` are now `Observable` rather than `Flowable` because the only backpressure strategy supported by `WatchService` is *drop*.

Other changes:
* `Files.events(File)` is now `Files.watch(File)`.
* Schedulers for nonBlocking approach are now specifiable only in the `pollInterval` method
* Specifying custom events now follows different builder paths (but is pretty clear). For example:

```java
Flowable<String> items = 
     Files
        .tailLines("/var/log/server.log")
        .events(Observable.interval(1, TimeUNIT.SECONDS))
        .build();
```
* README.md has been updated including all examples



